### PR TITLE
Add Custom DataTable Types Support

### DIFF
--- a/resources/features/custom-datatable-types/from-cell.feature
+++ b/resources/features/custom-datatable-types/from-cell.feature
@@ -1,0 +1,10 @@
+Feature: Defining Custom DataTable Types From DataTable Cells
+
+  Scenario: My Favorite Colors
+    Given that my favorite colors are:
+      | red    |
+      | blue   |
+      | black  |
+      | purple |
+    Then blue is one of my favorite colors
+    And green is not one of my favorite colors

--- a/resources/features/custom-datatable-types/from-entry.feature
+++ b/resources/features/custom-datatable-types/from-entry.feature
@@ -1,0 +1,13 @@
+Feature: Defining Custom DataTable Types From DataTable Entries
+
+  Scenario: Correct non-zero number of books found by author
+    Given I have the following books in the store
+      | title                                | author              |
+      | The Devil in the White City          | Erik Larson         |
+      | The Lion, the Witch and the Wardrobe | C.S. Lewis          |
+      | In the Garden of Beasts              | Erik Larson         |
+      | To Kill a Mockingbird                | Harper Lee          |
+      | The Catcher in the Rye               | J.D. Salinger       |
+      | The Great Gatsby                     | F. Scott Fitzgerald |
+    When I search for books by author "Erik Larson"
+    Then I find 2 books

--- a/resources/features/custom-datatable-types/from-row.feature
+++ b/resources/features/custom-datatable-types/from-row.feature
@@ -1,0 +1,15 @@
+Feature: Defining Custom DataTable Types From DataTable Rows
+
+  Scenario: Calculating Averages
+    Given I have the following rows of test scores
+      | 88 | 78 | 92 | 67 | 85 | 93 |
+      | 78 | 58 | 72 | 87 | 65 | 83 |
+      | 98 | 97 | 84 | 92 | 95 | 94 |
+    When I calculate the averages of each row
+    Then my state should look like this:
+    """
+      {:score-lists [[88 78 92 67 85 93]
+                     [78 58 72 87 65 83]
+                     [98 97 84 92 95 94]]
+       :averages    [83 73 93]}
+    """

--- a/resources/features/custom-datatable-types/from-table.feature
+++ b/resources/features/custom-datatable-types/from-table.feature
@@ -1,0 +1,16 @@
+Feature: Defining Custom DataTable Types From The Entire DataTable
+
+  Scenario: TicTacToe
+    Given I have the following tic-tac-toe board:
+      |   |   | o |
+      |   | x | o |
+      | x |   |   |
+    * the :topLeft square should be empty
+    * the :topMid square should be empty
+    * the :topRight square should be :o
+    * the :midLeft square should be empty
+    * the :midMid square should be :x
+    * the :midRight square should be :o
+    * the :botLeft square should be :x
+    * the :botMid square should be empty
+    * the :botRight square should be empty

--- a/src/burpless.clj
+++ b/src/burpless.clj
@@ -48,6 +48,31 @@
       :line               ~line
       :file               ~*file*}))
 
+(defmacro datatable-type
+  "Create a datatable-type map.
+  The following keys are required:
+  - :from-type -> one of the following keywords: :table, :row, :entry, :cell
+  - :to-type   -> the return type of the transform function, an instance of java.lang.reflect.Type
+  - :transform -> a function that is expected to receive an argument of one of the following types:
+                  :table -> DataTable  (the entire datatable)
+                  :row   -> List<String> (a list of cells in a datatable row)
+                  :entry -> Map<String, String> (a map of column names to column values), one for each row
+                  :cell  -> String (a single datable cell)
+
+                  The input argument corresponds to the value of :from-type
+                  The transform fn should return a value of :to-type"
+
+  [{:keys [to-type
+           from-type
+           transform]}]
+  (let [line (:line (meta &form))]
+    `{:glue-type :datatable-type
+      :to-type   ~to-type
+      :from-type ~from-type
+      :transform ~transform
+      :line      ~line
+      :file      ~*file*}))
+
 (defn run-cucumber
   "Run the cucumber features at `features-path` using the given `glues`.
 

--- a/test/custom_datatable_types_test.clj
+++ b/test/custom_datatable_types_test.clj
@@ -1,0 +1,123 @@
+(ns custom-datatable-types-test
+  (:require [burpless :refer [datatable-type parameter-type run-cucumber step]]
+            [clojure.test :refer [deftest is]])
+  (:import (clojure.lang Keyword)
+           (io.cucumber.datatable DataTable)
+           (io.cucumber.docstring DocString)
+           (java.util List)))
+
+
+;; FROM TABLE
+(defrecord TicTacToeBoard [topLeft topMid topRight
+                           midLeft midMid midRight
+                           botLeft botMid botRight])
+
+
+(def from-table-glues
+  [(step :Given "I have the following tic-tac-toe board:"
+         ^{:datatable TicTacToeBoard}
+         (fn [state ^TicTacToeBoard board]
+           (assoc state :board board)))
+
+   (step :Then "the {keyword} square should be empty"
+         (fn [{:keys [board] :as state} ^Keyword board-cell]
+           (assert (= nil (board-cell board)))
+           state))
+
+   (step :Then "the {keyword} square should be {keyword}"
+         (fn the_square_should_be [{:keys [board] :as state} ^Keyword board-cell ^Keyword expected-player]
+           (let [actual-player (board-cell board)]
+             (assert (= expected-player actual-player)))
+           state))
+
+   (datatable-type {:to-type   TicTacToeBoard
+                    :from-type :table
+                    :transform (fn [^DataTable table]
+                                 (apply ->TicTacToeBoard (map keyword (.values table))))})])
+
+(deftest from-table
+  (is (zero? (run-cucumber "resources/features/custom-datatable-types/from-table.feature" from-table-glues))))
+
+
+;; FROM ENTRY
+(defrecord Book [^String title ^String author])
+
+(def from-entry-glues
+  [(step :When "I search for books by author {string}"
+         (fn [state ^String author]
+           (assoc state :matching-books (filter (comp #{author} :author) (:book-store state)))))
+
+   (step :Then "I find {int} book(s)"
+         (fn [state ^Integer num-books]
+           (assert (= num-books (count (:matching-books state))))))
+
+   (step :Given "I have the following books in the store"
+         ^{:datatable [Book]}
+         (fn [state ^List books]
+           (assoc state :book-store books)))
+
+   (datatable-type {:to-type   Book
+                    :from-type :entry
+                    :transform (fn [{:strs [title author]}]
+                                 (->Book title author))})])
+
+(deftest from-entry
+  (is (zero? (run-cucumber "resources/features/custom-datatable-types/from-entry.feature" from-entry-glues))))
+
+
+;; FROM CELL
+(defrecord Color [name])
+
+(def from-cell-glues
+  [(parameter-type {:name      "color"
+                    :regexps   [#"\w+"]
+                    :to-type   Color
+                    :transform ->Color})
+
+   (step :Given "that my favorite colors are:"
+         ^{:datatable [Color]}
+         (fn [state ^List favorite-colors]
+           (assoc state :favorite-colors favorite-colors)))
+
+   (step :Then "{color} is one of my favorite colors"
+         (fn [{:keys [favorite-colors] :as state} ^Color candidate]
+           (assert (some? (some #{candidate} favorite-colors)))
+           state))
+
+   (step :Then "{color} is not one of my favorite colors"
+         (fn [{:keys [favorite-colors] :as state} ^Color candidate]
+           (assert (nil? (some #{candidate} favorite-colors)))
+           state))
+
+   (datatable-type {:to-type   Color
+                    :from-type :cell
+                    :transform ->Color})])
+
+(deftest from-cell
+  (is (zero? (run-cucumber "resources/features/custom-datatable-types/from-cell.feature" from-cell-glues))))
+
+
+;; FROM ROW
+(def from-row-glues
+  [(step :Given "I have the following rows of test scores"
+         ^{:datatable [List]}
+         (fn [state ^List score-lists]
+           (assoc state :score-lists score-lists)))
+
+   (step :When "I calculate the averages of each row"
+         (fn [{:keys [score-lists] :as state}]
+           (assoc state :averages (mapv (fn [sl] (quot (apply + sl) (count sl)))
+                                        score-lists))))
+
+   (step :Then "my state should look like this:"
+         ^:docstring
+         (fn [actual-state ^DocString docString]
+           (let [expected-state (read-string (.getContent docString))]
+             (is (= expected-state actual-state)))))
+
+   (datatable-type {:to-type   List
+                    :from-type :row
+                    :transform (partial mapv parse-long)})])
+
+(deftest from-row
+  (is (zero? (run-cucumber "resources/features/custom-datatable-types/from-row.feature" from-row-glues))))


### PR DESCRIPTION
All Tests Pass:
![image](https://github.com/danielmiladinov/burpless/assets/927811/de271edd-7a2e-40f8-859e-46a3554f9619)

```
Testing custom-parameter-types-test

Scenario: Custom Parameter Type: bar-map                           # resources/features/custom-parameter-types.feature:3
  Given my state starts out as an empty map                        # custom_parameter_types_test.clj:15
  And burpless innately supports keyword parameter types           # custom_parameter_types_test.clj:18
  And I want to add a bar-map of 42 under the :foo key of my state # custom_parameter_types_test.clj:20
  Then my state should look like this                              # custom_parameter_types_test.clj:24

1 Scenarios (1 passed)
4 Steps (4 passed)
0m0.054s



Testing custom-datatable-types-test

Scenario: Correct non-zero number of books found by author # resources/features/custom-datatable-types/from-entry.feature:3
  Given I have the following books in the store            # custom_datatable_types_test.clj:54
    | title                                | author              |
    | The Devil in the White City          | Erik Larson         |
    | The Lion, the Witch and the Wardrobe | C.S. Lewis          |
    | In the Garden of Beasts              | Erik Larson         |
    | To Kill a Mockingbird                | Harper Lee          |
    | The Catcher in the Rye               | J.D. Salinger       |
    | The Great Gatsby                     | F. Scott Fitzgerald |
  When I search for books by author "Erik Larson"          # custom_datatable_types_test.clj:46
  Then I find 2 books                                      # custom_datatable_types_test.clj:50

1 Scenarios (1 passed)
3 Steps (3 passed)
0m0.009s



Scenario: TicTacToe                             # resources/features/custom-datatable-types/from-table.feature:3
  Given I have the following tic-tac-toe board: # custom_datatable_types_test.clj:17
    | [empty] | [empty] | o       |
    | [empty] | x       | o       |
    | x       | [empty] | [empty] |
  * the :topLeft square should be empty         # custom_datatable_types_test.clj:22
  * the :topMid square should be empty          # custom_datatable_types_test.clj:22
  * the :topRight square should be :o           # custom_datatable_types_test.clj:27
  * the :midLeft square should be empty         # custom_datatable_types_test.clj:22
  * the :midMid square should be :x             # custom_datatable_types_test.clj:27
  * the :midRight square should be :o           # custom_datatable_types_test.clj:27
  * the :botLeft square should be :x            # custom_datatable_types_test.clj:27
  * the :botMid square should be empty          # custom_datatable_types_test.clj:22
  * the :botRight square should be empty        # custom_datatable_types_test.clj:22

1 Scenarios (1 passed)
10 Steps (10 passed)
0m0.005s



Scenario: My Favorite Colors                 # resources/features/custom-datatable-types/from-cell.feature:3
  Given that my favorite colors are:         # custom_datatable_types_test.clj:77
    | red    |
    | blue   |
    | black  |
    | purple |
  Then blue is one of my favorite colors     # custom_datatable_types_test.clj:82
  And green is not one of my favorite colors # custom_datatable_types_test.clj:87

1 Scenarios (1 passed)
3 Steps (3 passed)
0m0.006s



Scenario: Calculating Averages                   # resources/features/custom-datatable-types/from-row.feature:3
  Given I have the following rows of test scores # custom_datatable_types_test.clj:102
    | 88 | 78 | 92 | 67 | 85 | 93 |
    | 78 | 58 | 72 | 87 | 65 | 83 |
    | 98 | 97 | 84 | 92 | 95 | 94 |
  When I calculate the averages of each row      # custom_datatable_types_test.clj:107
  Then my state should look like this:           # custom_datatable_types_test.clj:112

1 Scenarios (1 passed)
3 Steps (3 passed)
0m0.004s



Testing cucumber-expression-parameter-type-extraction-test

Scenario: Int Type Extraction              # resources/features/cucumber-expression-parameter-type-extraction.feature:3
  When I have an int value of 42           # cucumber_expression_parameter_type_extraction_test.clj:6
  Then its int value should be 42          # cucumber_expression_parameter_type_extraction_test.clj:10
  And its type should be java.lang.Integer # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Float Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:8
  When I have a float value of 42.1      # cucumber_expression_parameter_type_extraction_test.clj:15
  Then its float value should be 42.1    # cucumber_expression_parameter_type_extraction_test.clj:19
  And its type should be java.lang.Float # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Word Type Extraction            # resources/features/cucumber-expression-parameter-type-extraction.feature:13
  When I have a word value of fabulous    # cucumber_expression_parameter_type_extraction_test.clj:24
  Then its word value should be fabulous  # cucumber_expression_parameter_type_extraction_test.clj:28
  And its type should be java.lang.String # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: String Type Extraction                               # resources/features/cucumber-expression-parameter-type-extraction.feature:18
  When I have a string value of "multiple words in a string"   # cucumber_expression_parameter_type_extraction_test.clj:33
  Then its string value should be "multiple words in a string" # cucumber_expression_parameter_type_extraction_test.clj:37
  And its type should be java.lang.String                      # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Anonymous Type Extraction                          # resources/features/cucumber-expression-parameter-type-extraction.feature:23
  When I have an anonymous value of anything can go in here  # cucumber_expression_parameter_type_extraction_test.clj:42
  Then its anonymous value should be anything can go in here # cucumber_expression_parameter_type_extraction_test.clj:46
  And its type should be java.lang.String                    # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: BigDecimal Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:28
  When I have a bigdecimal value of 456.238   # cucumber_expression_parameter_type_extraction_test.clj:51
  Then its bigdecimal value should be 456.238 # cucumber_expression_parameter_type_extraction_test.clj:55
  And its type should be java.math.BigDecimal # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Double Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:33
  When I have a double value of 12.489    # cucumber_expression_parameter_type_extraction_test.clj:60
  Then its double value should be 12.489  # cucumber_expression_parameter_type_extraction_test.clj:64
  And its type should be java.lang.Double # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: BigInteger Type Extraction               # resources/features/cucumber-expression-parameter-type-extraction.feature:38
  When I have a biginteger value of 234239023482   # cucumber_expression_parameter_type_extraction_test.clj:69
  Then its biginteger value should be 234239023482 # cucumber_expression_parameter_type_extraction_test.clj:73
  And its type should be java.math.BigInteger      # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Byte Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:43
  When I have a byte value of 10        # cucumber_expression_parameter_type_extraction_test.clj:78
  Then its byte value should be 10      # cucumber_expression_parameter_type_extraction_test.clj:82
  And its type should be java.lang.Byte # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Short Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:48
  When I have a short value of 5         # cucumber_expression_parameter_type_extraction_test.clj:87
  Then its short value should be 5       # cucumber_expression_parameter_type_extraction_test.clj:91
  And its type should be java.lang.Short # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Long Type Extraction             # resources/features/cucumber-expression-parameter-type-extraction.feature:53
  When I have a long value of 7133287829   # cucumber_expression_parameter_type_extraction_test.clj:96
  Then its long value should be 7133287829 # cucumber_expression_parameter_type_extraction_test.clj:100
  And its type should be java.lang.Long    # cucumber_expression_parameter_type_extraction_test.clj:105

11 Scenarios (11 passed)
33 Steps (33 passed)
0m0.051s



Testing simple-test

Scenario: Successful Test          # resources/features/simple.feature:3
  Given some setup                 # simple_test.clj:27
  When I do a thing                # simple_test.clj:31
  Then the setup happened          # simple_test.clj:35
  And the before hook happened     # simple_test.clj:40
  And the thing happened           # simple_test.clj:45
  And the before step counter is 6 # simple_test.clj:50
  And the after step counter is 6  # simple_test.clj:50

1 Scenarios (1 passed)
7 Steps (7 passed)
0m0.008s



Testing generative-test

Scenario: Positive integers are closed on addition # resources/features/generative.feature:3
  Given any positive integer X                     # generative_test.clj:11
  And any positive integer Y greater than X        # generative_test.clj:15
  Then X + Y is positive                           # generative_test.clj:29

Scenario: Ranged positive integers are closed on addition # resources/features/generative.feature:8
  Given any positive integer X                            # generative_test.clj:11
  And any integer Y from 10 to 20                         # generative_test.clj:21
  Then X + Y is positive                                  # generative_test.clj:29

Scenario: Regular steps           # resources/features/generative.feature:13
  Given any positive integer X    # generative_test.clj:11
  And any integer Y from 10 to 20 # generative_test.clj:21
  When a regular step happens     # generative_test.clj:25
  Then X + Y is positive          # generative_test.clj:29
  And the regular step happened   # generative_test.clj:39

3 Scenarios (3 passed)
11 Steps (11 passed)
0m0.018s



Testing scenario-outline-test

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:12
  Given today is "Sunday"                   # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:13
  Given today is "Monday"                   # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:14
  Given today is "Tuesday"                  # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:15
  Given today is "Wednesday"                # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:16
  Given today is "Thursday"                 # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:17
  Given today is "Friday"                   # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "TGIF!"             # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:18
  Given today is "Saturday"                 # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday            # resources/features/scenario-outline.feature:19
  Given today is "anything else!"                      # scenario_outline_test.clj:12
  When I ask whether it's Friday yet                   # scenario_outline_test.clj:16
  Then I should be told "That's not a day I recognize" # scenario_outline_test.clj:21

8 Scenarios (8 passed)
24 Steps (24 passed)
0m0.006s



Testing datatables-and-docstrings-test

Scenario: Populate State with DataTable inputs and compare against DocString input             # resources/features/datatables-and-docstrings.feature:3
  Given my state starts out as an empty map                                                    # datatables_and_docstrings_test.clj:11
  And I want to collect pairs of high and low temperatures under the :highs-and-lows state key # datatables_and_docstrings_test.clj:14
  When I have a table of the following high and low temperatures:                              # datatables_and_docstrings_test.clj:18
    | 81 | 49 |
    | 88 | 54 |
    | 76 | 56 |
    | 70 | 48 |
    | 81 | 55 |
  Then my state should be equal to the following Clojure literal:                              # datatables_and_docstrings_test.clj:37

Scenario: Converting Two-Column DataTables to Clojure maps        # resources/features/datatables-and-docstrings.feature:18
  Given I have a key-value table:                                 # datatables_and_docstrings_test.clj:23
    | numeric-value       | 1                                                      |
    | bigint-value        | 7823N                                                  |
    | double-value        | 1.327                                                  |
    | big-decimal-value   | 5.32M                                                  |
    | true-value          | true                                                   |
    | false-value         | false                                                  |
    | set-value           | #{"foo" "bar" "baz"}                                   |
    | vector-value        | [:foo "bar" {:baz true}]                               |
    | ratio-value         | 22/7                                                   |
    | uuid-value          | #uuid"e5fa994f-a073-4f9b-a05e-c8c6f2eea11c"            |
    | string-value        | Multi-word strings don't need to be enclosed in quotes |
    | quoted-string-value | "But they can be, if you prefer"                       |
    | keyword-value       | :some-keyword                                          |
    | nil-value           | [empty]                                                |
  Then my state should be equal to the following Clojure literal: # datatables_and_docstrings_test.clj:37

Scenario: Converting N-Column DataTables to sequences of Clojure maps # resources/features/datatables-and-docstrings.feature:52
  Given I have a table of data with key names in the first row:       # datatables_and_docstrings_test.clj:29
    | id | first-name | middle-name | last-name | favorite-color |
    | 1  | Charles    | John        | Taylor    | red            |
    | 2  | Brian      | [empty]     | Jones     | blue           |
    | 3  | William    | David       | Miller    | green          |
    | 4  | Robert     | [empty]     | Smith     | black          |
  Then my state should be equal to the following Clojure literal:     # datatables_and_docstrings_test.clj:37

3 Scenarios (3 passed)
8 Steps (8 passed)
0m0.008s



Process finished with exit code 0
```

Resolves #12