### PR TITLE
Do docstring types need to be parameterized?

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,8 +8,10 @@
            :resource-paths ["resources"]
 
            :test           {:extra-paths ["test"]
-                            :extra-deps  {org.clojure/test.check               {:mvn/version "1.1.1"}
-                                          io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}
+                            :extra-deps  {camel-snake-kebab/camel-snake-kebab  {:mvn/version "0.4.3"}
+                                          io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                                          org.clojure/data.json                {:mvn/version "2.4.0"}
+                                          org.clojure/test.check               {:mvn/version "1.1.1"}}}
 
            :build          {:deps       {io.github.clojure/tools.build {:mvn/version "0.9.6"}
                                          slipset/deps-deploy           {:mvn/version "0.2.0"}}

--- a/resources/features/custom-docstring-types/from-edn.feature
+++ b/resources/features/custom-docstring-types/from-edn.feature
@@ -1,0 +1,65 @@
+Feature: Burpless Innately Supports EDN DocStrings
+
+  Scenario: Populate State with DataTable inputs and compare against edn DocString input
+    Given my state starts out as an empty map
+    And I want to collect pairs of high and low temperatures under the :highs-and-lows state key
+    When I have a table of the following high and low temperatures:
+      | 81 | 49 |
+      | 88 | 54 |
+      | 76 | 56 |
+      | 70 | 48 |
+      | 81 | 55 |
+    Then my state should be equal to the following Clojure edn literal:
+    """edn
+    {:target-keyword :highs-and-lows
+     :highs-and-lows [[81 49] [88 54] [76 56] [70 48] [81 55]]}
+    """
+
+  Scenario: Converting Two-Column DataTables to Clojure maps
+    Given I have a key-value table:
+      | numeric-value       | 1                                                      |
+      | bigint-value        | 7823N                                                  |
+      | double-value        | 1.327                                                  |
+      | big-decimal-value   | 5.32M                                                  |
+      | true-value          | true                                                   |
+      | false-value         | false                                                  |
+      | set-value           | #{"foo" "bar" "baz"}                                   |
+      | vector-value        | [:foo "bar" {:baz true}]                               |
+      | ratio-value         | 22/7                                                   |
+      | uuid-value          | #uuid"e5fa994f-a073-4f9b-a05e-c8c6f2eea11c"            |
+      | string-value        | Multi-word strings don't need to be enclosed in quotes |
+      | quoted-string-value | "But they can be, if you prefer"                       |
+      | keyword-value       | :some-keyword                                          |
+      | nil-value           |                                                        |
+    Then my state should be equal to the following Clojure edn literal:
+    """edn
+      {:numeric-value       1
+       :bigint-value        7823N
+       :double-value        1.327
+       :big-decimal-value   5.32M
+       :true-value          true
+       :false-value         false
+       :set-value           #{"foo" "bar" "baz"}
+       :vector-value        [:foo "bar" {:baz true}]
+       :ratio-value         22/7
+       :uuid-value          #uuid "e5fa994f-a073-4f9b-a05e-c8c6f2eea11c"
+       :string-value        "Multi-word strings don't need to be enclosed in quotes"
+       :quoted-string-value "But they can be, if you prefer"
+       :keyword-value       :some-keyword
+       :nil-value           nil}
+     """
+
+  Scenario: Converting N-Column DataTables to sequences of Clojure maps
+    Given I have a table of data with key names in the first row:
+      | id | first-name | middle-name | last-name | favorite-color |
+      | 1  | Charles    | John        | Taylor    | red            |
+      | 2  | Brian      |             | Jones     | blue           |
+      | 3  | William    | David       | Miller    | green          |
+      | 4  | Robert     |             | Smith     | black          |
+    Then my state should be equal to the following Clojure edn literal:
+    """edn
+      [{:id 1 :first-name "Charles" :middle-name "John"  :last-name "Taylor" :favorite-color "red"}
+       {:id 2 :first-name "Brian"   :middle-name nil     :last-name "Jones"  :favorite-color "blue"}
+       {:id 3 :first-name "William" :middle-name "David" :last-name "Miller" :favorite-color "green"}
+       {:id 4 :first-name "Robert"  :middle-name nil     :last-name "Smith"  :favorite-color "black"}]
+    """

--- a/resources/features/custom-docstring-types/from-json.feature
+++ b/resources/features/custom-docstring-types/from-json.feature
@@ -1,0 +1,49 @@
+Feature: Burpless Supports Custom DocString Types, Such as JSON
+
+  Scenario: Populate state with values from custom DocString inputs and compare them for equality
+    Given that my state starts out as an empty map
+    And I want to store the following in my state's :json-sample key
+    """json
+    [
+      {
+        "id": "65439b9690b50f79a0752ed6",
+        "email": "terry_house@vortexaco.bargains",
+        "username": "terry91",
+        "profile": {
+          "name": "Terry House",
+          "company": "Vortexaco",
+          "dob": "1991-03-25",
+          "address": "1 Regent Place, Sussex, New York",
+          "location": {
+            "lat": 88.908225,
+            "long": 125.754369
+          },
+          "about": "Excepteur voluptate veniam quis laborum sunt. Anim dolor proident anim cupidatat magna laboris aliqua qui sint ea esse elit."
+        },
+        "apiKey": "c24efd57-e3fe-44f6-bb6e-df3063143b81",
+        "roles": [
+          "member"
+        ],
+        "createdAt": "2014-04-12T03:29:52.355Z",
+        "updatedAt": "2014-04-13T03:29:52.355Z"
+      }
+    ]
+    """
+    And I want to store the following in my state's :edn-sample key
+    """edn
+    [{:id         "65439b9690b50f79a0752ed6"
+      :email      "terry_house@vortexaco.bargains"
+      :username   "terry91"
+      :profile    {:name     "Terry House"
+                   :company  "Vortexaco"
+                   :dob      "1991-03-25"
+                   :address  "1 Regent Place, Sussex, New York"
+                   :location {:lat 88.908225 :long 125.754369}
+                   :about    "Excepteur voluptate veniam quis laborum sunt. Anim dolor proident anim cupidatat magna laboris aliqua qui sint ea esse elit."}
+      :api-key    "c24efd57-e3fe-44f6-bb6e-df3063143b81"
+      :roles      ["member"]
+      :created-at "2014-04-12T03:29:52.355Z"
+      :updated-at "2014-04-13T03:29:52.355Z"}]
+    """
+    When I compare the my state's :json-sample and :edn-sample keys to each other for equality, storing the result in :result
+    Then my state's :result equality value should be true

--- a/src/burpless.clj
+++ b/src/burpless.clj
@@ -73,6 +73,24 @@
       :line      ~line
       :file      ~*file*}))
 
+(defmacro docstring-type
+  "Create a docstring-type-map.
+  The following keys are required:
+  - :content-type -> the GFM info string or media type that decorates the docstrings you wish to transform
+  - :to-type      -> the return type of the transform function, an instance of java.lang.reflect.Type
+  - :transform    -> a function that is expected to receive the string content of the docstring, and transform it into
+                     the type represented by :to-type."
+  [{:keys [content-type
+           to-type
+           transform]}]
+  (let [line (:line (meta &form))]
+    `{:glue-type    :docstring-type
+      :content-type ~content-type
+      :to-type      ~to-type
+      :transform    ~transform
+      :line         ~line
+      :file         ~*file*}))
+
 (defn run-cucumber
   "Run the cucumber features at `features-path` using the given `glues`.
 

--- a/src/burpless/conversions.clj
+++ b/src/burpless/conversions.clj
@@ -1,4 +1,5 @@
 (ns burpless.conversions
+  (:require [clojure.edn :as edn])
   (:import (io.cucumber.datatable DataTable)))
 
 (defn read-cucumber-string
@@ -11,7 +12,7 @@
    then we should return the input string unchanged."
   [^String cucumber-string]
   (when cucumber-string
-    (let [result (read-string cucumber-string)]
+    (let [result (edn/read-string cucumber-string)]
       (if (symbol? result)
         cucumber-string
         result))))

--- a/src/burpless/runtime.clj
+++ b/src/burpless/runtime.clj
@@ -133,10 +133,26 @@
 
            (instance? Type docstring) docstring
 
+           ;; TODO - Do we need to support this? Maybe we need a real-world example or two...
+           (and (vector? docstring)
+                (< 1 (count docstring))
+                (instance? Type (first docstring))
+                (every? (partial instance? Type) (rest docstring)))
+           (let [[raw-type & type-arguments] docstring]
+             (reify ParameterizedType
+               ;; Type hint for Java Type array (i.e. Type[] in Java)
+               (^"[Ljava.lang.reflect.Type;" getActualTypeArguments [_]
+                 (into-array Type type-arguments))
+               (^Type getRawType [_]
+                 raw-type)
+               (^Type getOwnerType [_]
+                 nil)))
+
            :else
            (throw (ex-info (str "Unexpected step fn metadata - :datable value should either be:\n"
-                                "- boolean true, or\n"
-                                "- a Type instance\n")
+                                "- boolean true,\n"
+                                "- a Type instance, or\n"
+                                "- a vector describing a parameterized type - one raw type followed by one or more type arguments")
                            fn-metadata))))))
 
 (defn- to-step-definition

--- a/src/burpless/runtime.clj
+++ b/src/burpless/runtime.clj
@@ -250,13 +250,6 @@
                      (transform [_ ^String cell]
                        (transform cell))))))
 
-(defn- register-custom-datatable-type
-  "Given a custom DataTableType, add it to both the provided glue and the datatable type registry.
-  It must be added to both or else step functions will not be properly matched to gherkin steps at run time."
-  [^Glue glue ^DataTableTypeRegistry datatable-type-registry ^DataTableType datatable-type]
-  (.addDataTableType glue (reify DataTableTypeDefinition (^DataTableType dataTableType [_] datatable-type)))
-  (.defineDataTableType datatable-type-registry datatable-type))
-
 (defn- create-clojure-cucumber-backend
   "Given a collection of glues, return a Clojure-friendly Cucumber Backend implementation."
   (^Backend [glues state-atom]
@@ -265,11 +258,10 @@
      (reify Backend
        (^void loadGlue [_ ^Glue glue ^List _gluePaths]
          (let [locale                  (Locale/getDefault)
-               parameter-type-registry (ParameterTypeRegistry. locale)
-               datatable-type-registry (DataTableTypeRegistry. locale)]
+               parameter-type-registry (ParameterTypeRegistry. locale)]
 
            (doseq [datatable-type (map to-datatable-type datatable-types)]
-             (register-custom-datatable-type glue datatable-type-registry datatable-type))
+             (.addDataTableType glue (reify DataTableTypeDefinition (^DataTableType dataTableType [_] datatable-type))))
 
            (register-custom-parameter-type
              glue

--- a/src/burpless/runtime.clj
+++ b/src/burpless/runtime.clj
@@ -279,8 +279,11 @@
 (defn- create-clojure-cucumber-backend
   "Given a collection of glues, return a Clojure-friendly Cucumber Backend implementation."
   (^Backend [glues state-atom]
-   (let [{steps :step hooks :hook parameter-types :parameter-type datatable-types :datatable-type}
-         (group-by :glue-type glues)]
+   (let [{steps           :step
+          hooks           :hook
+          parameter-types :parameter-type
+          datatable-types :datatable-type
+          docstring-types :docstring-type} (group-by :glue-type glues)]
      (reify Backend
        (^void loadGlue [_ ^Glue glue ^List _gluePaths]
          (let [locale                  (Locale/getDefault)
@@ -294,6 +297,9 @@
                                        (to-docstring-type {:content-type "edn"
                                                            :to-type      IObj
                                                            :transform    edn/read-string}))))
+
+           (doseq [docstring-type (map to-docstring-type docstring-types)]
+             (.addDocStringType glue (reify DocStringTypeDefinition (^DocStringType docStringType [_] docstring-type))))
 
            (register-custom-parameter-type
              glue

--- a/test/custom_docstring_types_test.clj
+++ b/test/custom_docstring_types_test.clj
@@ -1,9 +1,11 @@
 (ns custom-docstring-types-test
-  (:require [burpless :refer [run-cucumber step]]
+  (:require [burpless :refer [docstring-type parameter-type run-cucumber step]]
             [burpless.conversions :as conversions]
+            [camel-snake-kebab.core :as csk]
+            [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.test :refer [deftest is]])
-  (:import (clojure.lang IObj)
+  (:import (clojure.lang IObj Keyword)
            (io.cucumber.datatable DataTable)
            (java.lang.reflect Type)))
 
@@ -38,3 +40,33 @@
 
 (deftest from-edn
   (is (zero? (run-cucumber "resources/features/custom-docstring-types/from-edn.feature" from-edn-steps))))
+
+
+(def from-json-steps
+  [(step :Given "that my state starts out as an empty map"
+         (constantly {}))
+
+   (step :Given "I want to store the following in my state's {keyword} key"
+         ^{:docstring IObj}
+         (fn [state ^Keyword kw ^IObj data]
+           (assoc state kw data)))
+
+   (step :When "I compare the my state's {keyword} and {keyword} keys to each other for equality, storing the result in {keyword}"
+         (fn [state ^Keyword kw-1 ^Keyword kw-2 ^Keyword kw-3]
+           (assoc state kw-3 (= (kw-1 state) (kw-2 state)))))
+
+   (step :Then "my state's {keyword} equality value should be {boolean}"
+         (fn [state ^Keyword kw ^Boolean equal?]
+           (assert equal? (kw state))
+           state))
+
+   (docstring-type {:content-type "json"
+                    :to-type      IObj
+                    :transform    (fn [s] (json/read-str s :key-fn csk/->kebab-case-keyword))})
+
+   (parameter-type {:name      "boolean"
+                    :regexps   [#"(?i)true|false"]
+                    :to-type   Boolean
+                    :transform (fn [s] (Boolean/valueOf ^String s))})])
+(deftest from-json
+  (is (zero? (run-cucumber "resources/features/custom-docstring-types/from-json.feature" from-json-steps))))

--- a/test/custom_docstring_types_test.clj
+++ b/test/custom_docstring_types_test.clj
@@ -1,0 +1,40 @@
+(ns custom-docstring-types-test
+  (:require [burpless :refer [run-cucumber step]]
+            [burpless.conversions :as conversions]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is]])
+  (:import (clojure.lang IObj)
+           (io.cucumber.datatable DataTable)
+           (java.lang.reflect Type)))
+
+(def from-edn-steps
+  [(step :Given "my state starts out as an empty map"
+         (constantly {}))
+
+   (step :Given "I want to collect pairs of high and low temperatures under the {word} state key"
+         (fn [state keyword-name]
+           (assoc state :target-keyword (keyword (str/replace keyword-name #":" "")))))
+
+   (step :When "I have a table of the following high and low temperatures:"
+         ^:datatable
+         (fn [state ^DataTable dataTable]
+           (assoc state :highs-and-lows (.asLists dataTable ^Type Long))))
+
+   (step :Given "I have a key-value table:"
+         ^:datatable
+         (fn [_state ^DataTable dataTable]
+           (conversions/key-value-table->map dataTable)))
+
+
+   (step :Given "I have a table of data with key names in the first row:"
+         ^:datatable
+         (fn [_state ^DataTable dataTable]
+           (conversions/data-table->maps dataTable)))
+
+   (step :Then "my state should be equal to the following Clojure edn literal:"
+         ^{:docstring IObj}
+         (fn [actual-state ^IObj expected-state]
+           (is (= expected-state actual-state))))])
+
+(deftest from-edn
+  (is (zero? (run-cucumber "resources/features/custom-docstring-types/from-edn.feature" from-edn-steps))))

--- a/test/datatables_and_docstrings_test.clj
+++ b/test/datatables_and_docstrings_test.clj
@@ -29,16 +29,13 @@
    (step :Given "I have a table of data with key names in the first row:"
          ^:datatable
          (fn [_state ^DataTable dataTable]
-           ;; Write code here that turns the phrase above into concrete actions
-           ;; Be sure to also adorn your step function with the ^:datatable metadata
-           ;; in order for the runtime to properly identify it and pass the datatable argument
            (conversions/data-table->maps dataTable)))
 
    (step :Then "my state should be equal to the following Clojure literal:"
          ^:docstring
          (fn [actual-state ^DocString docString]
-           (let [expected-state (read-string (.getContent docString))]
-             (is (= expected-state actual-state)))))])
+           (let [expected-state (conversions/read-cucumber-string (.getContent docString))]
+             (assert (= expected-state actual-state)))))])
 
 (deftest datatable-and-docstrings
   (is (zero? (run-cucumber "resources/features/datatables-and-docstrings.feature" datatables-and-docstrings-steps))))


### PR DESCRIPTION
Do we need to support parameterized DocString types? Coming from Clojure, will we ever _really need_ to distinguish between, say, for example, `Map<String, String>` from `Map<String, Object>`, or `Map<Keyword, IObj>`, when the underlying raw type for all of these is just `Map`?

This would only really be an issue if / when we need to support multiple variants of parameterized maps, each with their own transform function, but all having the same content-type, and saying that their :to-type is just `Map` isn't specific enough…