### PR TITLE
Add Custom DocString Types Support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,8 +8,10 @@
            :resource-paths ["resources"]
 
            :test           {:extra-paths ["test"]
-                            :extra-deps  {org.clojure/test.check               {:mvn/version "1.1.1"}
-                                          io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}
+                            :extra-deps  {camel-snake-kebab/camel-snake-kebab  {:mvn/version "0.4.3"}
+                                          io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                                          org.clojure/data.json                {:mvn/version "2.4.0"}
+                                          org.clojure/test.check               {:mvn/version "1.1.1"}}}
 
            :build          {:deps       {io.github.clojure/tools.build {:mvn/version "0.9.6"}
                                          slipset/deps-deploy           {:mvn/version "0.2.0"}}

--- a/resources/features/custom-docstring-types/from-edn.feature
+++ b/resources/features/custom-docstring-types/from-edn.feature
@@ -1,0 +1,65 @@
+Feature: Burpless Innately Supports EDN DocStrings
+
+  Scenario: Populate State with DataTable inputs and compare against edn DocString input
+    Given my state starts out as an empty map
+    And I want to collect pairs of high and low temperatures under the :highs-and-lows state key
+    When I have a table of the following high and low temperatures:
+      | 81 | 49 |
+      | 88 | 54 |
+      | 76 | 56 |
+      | 70 | 48 |
+      | 81 | 55 |
+    Then my state should be equal to the following Clojure edn literal:
+    """edn
+    {:target-keyword :highs-and-lows
+     :highs-and-lows [[81 49] [88 54] [76 56] [70 48] [81 55]]}
+    """
+
+  Scenario: Converting Two-Column DataTables to Clojure maps
+    Given I have a key-value table:
+      | numeric-value       | 1                                                      |
+      | bigint-value        | 7823N                                                  |
+      | double-value        | 1.327                                                  |
+      | big-decimal-value   | 5.32M                                                  |
+      | true-value          | true                                                   |
+      | false-value         | false                                                  |
+      | set-value           | #{"foo" "bar" "baz"}                                   |
+      | vector-value        | [:foo "bar" {:baz true}]                               |
+      | ratio-value         | 22/7                                                   |
+      | uuid-value          | #uuid"e5fa994f-a073-4f9b-a05e-c8c6f2eea11c"            |
+      | string-value        | Multi-word strings don't need to be enclosed in quotes |
+      | quoted-string-value | "But they can be, if you prefer"                       |
+      | keyword-value       | :some-keyword                                          |
+      | nil-value           |                                                        |
+    Then my state should be equal to the following Clojure edn literal:
+    """edn
+      {:numeric-value       1
+       :bigint-value        7823N
+       :double-value        1.327
+       :big-decimal-value   5.32M
+       :true-value          true
+       :false-value         false
+       :set-value           #{"foo" "bar" "baz"}
+       :vector-value        [:foo "bar" {:baz true}]
+       :ratio-value         22/7
+       :uuid-value          #uuid "e5fa994f-a073-4f9b-a05e-c8c6f2eea11c"
+       :string-value        "Multi-word strings don't need to be enclosed in quotes"
+       :quoted-string-value "But they can be, if you prefer"
+       :keyword-value       :some-keyword
+       :nil-value           nil}
+     """
+
+  Scenario: Converting N-Column DataTables to sequences of Clojure maps
+    Given I have a table of data with key names in the first row:
+      | id | first-name | middle-name | last-name | favorite-color |
+      | 1  | Charles    | John        | Taylor    | red            |
+      | 2  | Brian      |             | Jones     | blue           |
+      | 3  | William    | David       | Miller    | green          |
+      | 4  | Robert     |             | Smith     | black          |
+    Then my state should be equal to the following Clojure edn literal:
+    """edn
+      [{:id 1 :first-name "Charles" :middle-name "John"  :last-name "Taylor" :favorite-color "red"}
+       {:id 2 :first-name "Brian"   :middle-name nil     :last-name "Jones"  :favorite-color "blue"}
+       {:id 3 :first-name "William" :middle-name "David" :last-name "Miller" :favorite-color "green"}
+       {:id 4 :first-name "Robert"  :middle-name nil     :last-name "Smith"  :favorite-color "black"}]
+    """

--- a/resources/features/custom-docstring-types/from-json.feature
+++ b/resources/features/custom-docstring-types/from-json.feature
@@ -1,0 +1,49 @@
+Feature: Burpless Supports Custom DocString Types, Such as JSON
+
+  Scenario: Populate state with values from custom DocString inputs and compare them for equality
+    Given that my state starts out as an empty map
+    And I want to store the following in my state's :json-sample key
+    """json
+    [
+      {
+        "id": "65439b9690b50f79a0752ed6",
+        "email": "terry_house@vortexaco.bargains",
+        "username": "terry91",
+        "profile": {
+          "name": "Terry House",
+          "company": "Vortexaco",
+          "dob": "1991-03-25",
+          "address": "1 Regent Place, Sussex, New York",
+          "location": {
+            "lat": 88.908225,
+            "long": 125.754369
+          },
+          "about": "Excepteur voluptate veniam quis laborum sunt. Anim dolor proident anim cupidatat magna laboris aliqua qui sint ea esse elit."
+        },
+        "apiKey": "c24efd57-e3fe-44f6-bb6e-df3063143b81",
+        "roles": [
+          "member"
+        ],
+        "createdAt": "2014-04-12T03:29:52.355Z",
+        "updatedAt": "2014-04-13T03:29:52.355Z"
+      }
+    ]
+    """
+    And I want to store the following in my state's :edn-sample key
+    """edn
+    [{:id         "65439b9690b50f79a0752ed6"
+      :email      "terry_house@vortexaco.bargains"
+      :username   "terry91"
+      :profile    {:name     "Terry House"
+                   :company  "Vortexaco"
+                   :dob      "1991-03-25"
+                   :address  "1 Regent Place, Sussex, New York"
+                   :location {:lat 88.908225 :long 125.754369}
+                   :about    "Excepteur voluptate veniam quis laborum sunt. Anim dolor proident anim cupidatat magna laboris aliqua qui sint ea esse elit."}
+      :api-key    "c24efd57-e3fe-44f6-bb6e-df3063143b81"
+      :roles      ["member"]
+      :created-at "2014-04-12T03:29:52.355Z"
+      :updated-at "2014-04-13T03:29:52.355Z"}]
+    """
+    When I compare the my state's :json-sample and :edn-sample keys to each other for equality, storing the result in :result
+    Then my state's :result equality value should be true

--- a/src/burpless.clj
+++ b/src/burpless.clj
@@ -73,6 +73,24 @@
       :line      ~line
       :file      ~*file*}))
 
+(defmacro docstring-type
+  "Create a docstring-type-map.
+  The following keys are required:
+  - :content-type -> the GFM info string or media type that decorates the docstrings you wish to transform
+  - :to-type      -> the return type of the transform function, an instance of java.lang.reflect.Type
+  - :transform    -> a function that is expected to receive the string content of the docstring, and transform it into
+                     the type represented by :to-type."
+  [{:keys [content-type
+           to-type
+           transform]}]
+  (let [line (:line (meta &form))]
+    `{:glue-type    :docstring-type
+      :content-type ~content-type
+      :to-type      ~to-type
+      :transform    ~transform
+      :line         ~line
+      :file         ~*file*}))
+
 (defn run-cucumber
   "Run the cucumber features at `features-path` using the given `glues`.
 

--- a/src/burpless/conversions.clj
+++ b/src/burpless/conversions.clj
@@ -1,4 +1,5 @@
 (ns burpless.conversions
+  (:require [clojure.edn :as edn])
   (:import (io.cucumber.datatable DataTable)))
 
 (defn read-cucumber-string
@@ -11,7 +12,7 @@
    then we should return the input string unchanged."
   [^String cucumber-string]
   (when cucumber-string
-    (let [result (read-string cucumber-string)]
+    (let [result (edn/read-string cucumber-string)]
       (if (symbol? result)
         cucumber-string
         result))))

--- a/src/burpless/runtime.clj
+++ b/src/burpless/runtime.clj
@@ -250,13 +250,6 @@
                      (transform [_ ^String cell]
                        (transform cell))))))
 
-(defn- register-custom-datatable-type
-  "Given a custom DataTableType, add it to both the provided glue and the datatable type registry.
-  It must be added to both or else step functions will not be properly matched to gherkin steps at run time."
-  [^Glue glue ^DataTableTypeRegistry datatable-type-registry ^DataTableType datatable-type]
-  (.addDataTableType glue (reify DataTableTypeDefinition (^DataTableType dataTableType [_] datatable-type)))
-  (.defineDataTableType datatable-type-registry datatable-type))
-
 (defn- create-clojure-cucumber-backend
   "Given a collection of glues, return a Clojure-friendly Cucumber Backend implementation."
   (^Backend [glues state-atom]
@@ -265,11 +258,10 @@
      (reify Backend
        (^void loadGlue [_ ^Glue glue ^List _gluePaths]
          (let [locale                  (Locale/getDefault)
-               parameter-type-registry (ParameterTypeRegistry. locale)
-               datatable-type-registry (DataTableTypeRegistry. locale)]
+               parameter-type-registry (ParameterTypeRegistry. locale)]
 
            (doseq [datatable-type (map to-datatable-type datatable-types)]
-             (register-custom-datatable-type glue datatable-type-registry datatable-type))
+             (.addDataTableType glue (reify DataTableTypeDefinition (^DataTableType dataTableType [_] datatable-type))))
 
            (register-custom-parameter-type
              glue

--- a/src/burpless/runtime.clj
+++ b/src/burpless/runtime.clj
@@ -279,8 +279,11 @@
 (defn- create-clojure-cucumber-backend
   "Given a collection of glues, return a Clojure-friendly Cucumber Backend implementation."
   (^Backend [glues state-atom]
-   (let [{steps :step hooks :hook parameter-types :parameter-type datatable-types :datatable-type}
-         (group-by :glue-type glues)]
+   (let [{steps           :step
+          hooks           :hook
+          parameter-types :parameter-type
+          datatable-types :datatable-type
+          docstring-types :docstring-type} (group-by :glue-type glues)]
      (reify Backend
        (^void loadGlue [_ ^Glue glue ^List _gluePaths]
          (let [locale                  (Locale/getDefault)
@@ -294,6 +297,9 @@
                                        (to-docstring-type {:content-type "edn"
                                                            :to-type      IObj
                                                            :transform    edn/read-string}))))
+
+           (doseq [docstring-type (map to-docstring-type docstring-types)]
+             (.addDocStringType glue (reify DocStringTypeDefinition (^DocStringType docStringType [_] docstring-type))))
 
            (register-custom-parameter-type
              glue

--- a/test/custom_docstring_types_test.clj
+++ b/test/custom_docstring_types_test.clj
@@ -1,9 +1,11 @@
 (ns custom-docstring-types-test
-  (:require [burpless :refer [run-cucumber step]]
+  (:require [burpless :refer [docstring-type parameter-type run-cucumber step]]
             [burpless.conversions :as conversions]
+            [camel-snake-kebab.core :as csk]
+            [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.test :refer [deftest is]])
-  (:import (clojure.lang IObj)
+  (:import (clojure.lang IObj Keyword)
            (io.cucumber.datatable DataTable)
            (java.lang.reflect Type)))
 
@@ -38,3 +40,33 @@
 
 (deftest from-edn
   (is (zero? (run-cucumber "resources/features/custom-docstring-types/from-edn.feature" from-edn-steps))))
+
+
+(def from-json-steps
+  [(step :Given "that my state starts out as an empty map"
+         (constantly {}))
+
+   (step :Given "I want to store the following in my state's {keyword} key"
+         ^{:docstring IObj}
+         (fn [state ^Keyword kw ^IObj data]
+           (assoc state kw data)))
+
+   (step :When "I compare the my state's {keyword} and {keyword} keys to each other for equality, storing the result in {keyword}"
+         (fn [state ^Keyword kw-1 ^Keyword kw-2 ^Keyword kw-3]
+           (assoc state kw-3 (= (kw-1 state) (kw-2 state)))))
+
+   (step :Then "my state's {keyword} equality value should be {boolean}"
+         (fn [state ^Keyword kw ^Boolean equal?]
+           (assert equal? (kw state))
+           state))
+
+   (docstring-type {:content-type "json"
+                    :to-type      IObj
+                    :transform    (fn [s] (json/read-str s :key-fn csk/->kebab-case-keyword))})
+
+   (parameter-type {:name      "boolean"
+                    :regexps   [#"(?i)true|false"]
+                    :to-type   Boolean
+                    :transform (fn [s] (Boolean/valueOf ^String s))})])
+(deftest from-json
+  (is (zero? (run-cucumber "resources/features/custom-docstring-types/from-json.feature" from-json-steps))))

--- a/test/custom_docstring_types_test.clj
+++ b/test/custom_docstring_types_test.clj
@@ -1,0 +1,40 @@
+(ns custom-docstring-types-test
+  (:require [burpless :refer [run-cucumber step]]
+            [burpless.conversions :as conversions]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is]])
+  (:import (clojure.lang IObj)
+           (io.cucumber.datatable DataTable)
+           (java.lang.reflect Type)))
+
+(def from-edn-steps
+  [(step :Given "my state starts out as an empty map"
+         (constantly {}))
+
+   (step :Given "I want to collect pairs of high and low temperatures under the {word} state key"
+         (fn [state keyword-name]
+           (assoc state :target-keyword (keyword (str/replace keyword-name #":" "")))))
+
+   (step :When "I have a table of the following high and low temperatures:"
+         ^:datatable
+         (fn [state ^DataTable dataTable]
+           (assoc state :highs-and-lows (.asLists dataTable ^Type Long))))
+
+   (step :Given "I have a key-value table:"
+         ^:datatable
+         (fn [_state ^DataTable dataTable]
+           (conversions/key-value-table->map dataTable)))
+
+
+   (step :Given "I have a table of data with key names in the first row:"
+         ^:datatable
+         (fn [_state ^DataTable dataTable]
+           (conversions/data-table->maps dataTable)))
+
+   (step :Then "my state should be equal to the following Clojure edn literal:"
+         ^{:docstring IObj}
+         (fn [actual-state ^IObj expected-state]
+           (is (= expected-state actual-state))))])
+
+(deftest from-edn
+  (is (zero? (run-cucumber "resources/features/custom-docstring-types/from-edn.feature" from-edn-steps))))

--- a/test/datatables_and_docstrings_test.clj
+++ b/test/datatables_and_docstrings_test.clj
@@ -29,16 +29,13 @@
    (step :Given "I have a table of data with key names in the first row:"
          ^:datatable
          (fn [_state ^DataTable dataTable]
-           ;; Write code here that turns the phrase above into concrete actions
-           ;; Be sure to also adorn your step function with the ^:datatable metadata
-           ;; in order for the runtime to properly identify it and pass the datatable argument
            (conversions/data-table->maps dataTable)))
 
    (step :Then "my state should be equal to the following Clojure literal:"
          ^:docstring
          (fn [actual-state ^DocString docString]
-           (let [expected-state (read-string (.getContent docString))]
-             (is (= expected-state actual-state)))))])
+           (let [expected-state (conversions/read-cucumber-string (.getContent docString))]
+             (assert (= expected-state actual-state)))))])
 
 (deftest datatable-and-docstrings
   (is (zero? (run-cucumber "resources/features/datatables-and-docstrings.feature" datatables-and-docstrings-steps))))


### PR DESCRIPTION
All tests pass:
![image](https://github.com/danielmiladinov/burpless/assets/927811/bd5995bb-2718-4871-ab3e-c0e92244ca88)

```
Testing custom-parameter-types-test

Scenario: Custom Parameter Type: bar-map                           # resources/features/custom-parameter-types.feature:3
  Given my state starts out as an empty map                        # custom_parameter_types_test.clj:15
  And burpless innately supports keyword parameter types           # custom_parameter_types_test.clj:18
  And I want to add a bar-map of 42 under the :foo key of my state # custom_parameter_types_test.clj:20
  Then my state should look like this                              # custom_parameter_types_test.clj:24

1 Scenarios (1 passed)
4 Steps (4 passed)
0m0.055s



Testing custom-datatable-types-test

Scenario: Correct non-zero number of books found by author # resources/features/custom-datatable-types/from-entry.feature:3
  Given I have the following books in the store            # custom_datatable_types_test.clj:54
    | title                                | author              |
    | The Devil in the White City          | Erik Larson         |
    | The Lion, the Witch and the Wardrobe | C.S. Lewis          |
    | In the Garden of Beasts              | Erik Larson         |
    | To Kill a Mockingbird                | Harper Lee          |
    | The Catcher in the Rye               | J.D. Salinger       |
    | The Great Gatsby                     | F. Scott Fitzgerald |
  When I search for books by author "Erik Larson"          # custom_datatable_types_test.clj:46
  Then I find 2 books                                      # custom_datatable_types_test.clj:50

1 Scenarios (1 passed)
3 Steps (3 passed)
0m0.006s



Scenario: TicTacToe                             # resources/features/custom-datatable-types/from-table.feature:3
  Given I have the following tic-tac-toe board: # custom_datatable_types_test.clj:17
    | [empty] | [empty] | o       |
    | [empty] | x       | o       |
    | x       | [empty] | [empty] |
  * the :topLeft square should be empty         # custom_datatable_types_test.clj:22
  * the :topMid square should be empty          # custom_datatable_types_test.clj:22
  * the :topRight square should be :o           # custom_datatable_types_test.clj:27
  * the :midLeft square should be empty         # custom_datatable_types_test.clj:22
  * the :midMid square should be :x             # custom_datatable_types_test.clj:27
  * the :midRight square should be :o           # custom_datatable_types_test.clj:27
  * the :botLeft square should be :x            # custom_datatable_types_test.clj:27
  * the :botMid square should be empty          # custom_datatable_types_test.clj:22
  * the :botRight square should be empty        # custom_datatable_types_test.clj:22

1 Scenarios (1 passed)
10 Steps (10 passed)
0m0.005s



Scenario: My Favorite Colors                 # resources/features/custom-datatable-types/from-cell.feature:3
  Given that my favorite colors are:         # custom_datatable_types_test.clj:77
    | red    |
    | blue   |
    | black  |
    | purple |
  Then blue is one of my favorite colors     # custom_datatable_types_test.clj:82
  And green is not one of my favorite colors # custom_datatable_types_test.clj:87

1 Scenarios (1 passed)
3 Steps (3 passed)
0m0.006s



Scenario: Calculating Averages                   # resources/features/custom-datatable-types/from-row.feature:3
  Given I have the following rows of test scores # custom_datatable_types_test.clj:102
    | 88 | 78 | 92 | 67 | 85 | 93 |
    | 78 | 58 | 72 | 87 | 65 | 83 |
    | 98 | 97 | 84 | 92 | 95 | 94 |
  When I calculate the averages of each row      # custom_datatable_types_test.clj:107
  Then my state should look like this:           # custom_datatable_types_test.clj:112

1 Scenarios (1 passed)
3 Steps (3 passed)
0m0.004s



Testing cucumber-expression-parameter-type-extraction-test

Scenario: Int Type Extraction              # resources/features/cucumber-expression-parameter-type-extraction.feature:3
  When I have an int value of 42           # cucumber_expression_parameter_type_extraction_test.clj:6
  Then its int value should be 42          # cucumber_expression_parameter_type_extraction_test.clj:10
  And its type should be java.lang.Integer # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Float Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:8
  When I have a float value of 42.1      # cucumber_expression_parameter_type_extraction_test.clj:15
  Then its float value should be 42.1    # cucumber_expression_parameter_type_extraction_test.clj:19
  And its type should be java.lang.Float # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Word Type Extraction            # resources/features/cucumber-expression-parameter-type-extraction.feature:13
  When I have a word value of fabulous    # cucumber_expression_parameter_type_extraction_test.clj:24
  Then its word value should be fabulous  # cucumber_expression_parameter_type_extraction_test.clj:28
  And its type should be java.lang.String # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: String Type Extraction                               # resources/features/cucumber-expression-parameter-type-extraction.feature:18
  When I have a string value of "multiple words in a string"   # cucumber_expression_parameter_type_extraction_test.clj:33
  Then its string value should be "multiple words in a string" # cucumber_expression_parameter_type_extraction_test.clj:37
  And its type should be java.lang.String                      # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Anonymous Type Extraction                          # resources/features/cucumber-expression-parameter-type-extraction.feature:23
  When I have an anonymous value of anything can go in here  # cucumber_expression_parameter_type_extraction_test.clj:42
  Then its anonymous value should be anything can go in here # cucumber_expression_parameter_type_extraction_test.clj:46
  And its type should be java.lang.String                    # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: BigDecimal Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:28
  When I have a bigdecimal value of 456.238   # cucumber_expression_parameter_type_extraction_test.clj:51
  Then its bigdecimal value should be 456.238 # cucumber_expression_parameter_type_extraction_test.clj:55
  And its type should be java.math.BigDecimal # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Double Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:33
  When I have a double value of 12.489    # cucumber_expression_parameter_type_extraction_test.clj:60
  Then its double value should be 12.489  # cucumber_expression_parameter_type_extraction_test.clj:64
  And its type should be java.lang.Double # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: BigInteger Type Extraction               # resources/features/cucumber-expression-parameter-type-extraction.feature:38
  When I have a biginteger value of 234239023482   # cucumber_expression_parameter_type_extraction_test.clj:69
  Then its biginteger value should be 234239023482 # cucumber_expression_parameter_type_extraction_test.clj:73
  And its type should be java.math.BigInteger      # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Byte Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:43
  When I have a byte value of 10        # cucumber_expression_parameter_type_extraction_test.clj:78
  Then its byte value should be 10      # cucumber_expression_parameter_type_extraction_test.clj:82
  And its type should be java.lang.Byte # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Short Type Extraction          # resources/features/cucumber-expression-parameter-type-extraction.feature:48
  When I have a short value of 5         # cucumber_expression_parameter_type_extraction_test.clj:87
  Then its short value should be 5       # cucumber_expression_parameter_type_extraction_test.clj:91
  And its type should be java.lang.Short # cucumber_expression_parameter_type_extraction_test.clj:105

Scenario: Long Type Extraction             # resources/features/cucumber-expression-parameter-type-extraction.feature:53
  When I have a long value of 7133287829   # cucumber_expression_parameter_type_extraction_test.clj:96
  Then its long value should be 7133287829 # cucumber_expression_parameter_type_extraction_test.clj:100
  And its type should be java.lang.Long    # cucumber_expression_parameter_type_extraction_test.clj:105

11 Scenarios (11 passed)
33 Steps (33 passed)
0m0.026s



Testing simple-test

Scenario: Successful Test          # resources/features/simple.feature:3
  Given some setup                 # simple_test.clj:27
  When I do a thing                # simple_test.clj:31
  Then the setup happened          # simple_test.clj:35
  And the before hook happened     # simple_test.clj:40
  And the thing happened           # simple_test.clj:45
  And the before step counter is 6 # simple_test.clj:50
  And the after step counter is 6  # simple_test.clj:50

1 Scenarios (1 passed)
7 Steps (7 passed)
0m0.006s



Testing generative-test

Scenario: Positive integers are closed on addition # resources/features/generative.feature:3
  Given any positive integer X                     # generative_test.clj:11
  And any positive integer Y greater than X        # generative_test.clj:15
  Then X + Y is positive                           # generative_test.clj:29

Scenario: Ranged positive integers are closed on addition # resources/features/generative.feature:8
  Given any positive integer X                            # generative_test.clj:11
  And any integer Y from 10 to 20                         # generative_test.clj:21
  Then X + Y is positive                                  # generative_test.clj:29

Scenario: Regular steps           # resources/features/generative.feature:13
  Given any positive integer X    # generative_test.clj:11
  And any integer Y from 10 to 20 # generative_test.clj:21
  When a regular step happens     # generative_test.clj:25
  Then X + Y is positive          # generative_test.clj:29
  And the regular step happened   # generative_test.clj:39

3 Scenarios (3 passed)
11 Steps (11 passed)
0m0.018s



Testing custom-docstring-types-test

Scenario: Populate State with DataTable inputs and compare against edn DocString input         # resources/features/custom-docstring-types/from-edn.feature:3
  Given my state starts out as an empty map                                                    # custom_docstring_types_test.clj:13
  And I want to collect pairs of high and low temperatures under the :highs-and-lows state key # custom_docstring_types_test.clj:16
  When I have a table of the following high and low temperatures:                              # custom_docstring_types_test.clj:20
    | 81 | 49 |
    | 88 | 54 |
    | 76 | 56 |
    | 70 | 48 |
    | 81 | 55 |
  Then my state should be equal to the following Clojure edn literal:                          # custom_docstring_types_test.clj:36

Scenario: Converting Two-Column DataTables to Clojure maps            # resources/features/custom-docstring-types/from-edn.feature:18
  Given I have a key-value table:                                     # custom_docstring_types_test.clj:25
    | numeric-value       | 1                                                      |
    | bigint-value        | 7823N                                                  |
    | double-value        | 1.327                                                  |
    | big-decimal-value   | 5.32M                                                  |
    | true-value          | true                                                   |
    | false-value         | false                                                  |
    | set-value           | #{"foo" "bar" "baz"}                                   |
    | vector-value        | [:foo "bar" {:baz true}]                               |
    | ratio-value         | 22/7                                                   |
    | uuid-value          | #uuid"e5fa994f-a073-4f9b-a05e-c8c6f2eea11c"            |
    | string-value        | Multi-word strings don't need to be enclosed in quotes |
    | quoted-string-value | "But they can be, if you prefer"                       |
    | keyword-value       | :some-keyword                                          |
    | nil-value           | [empty]                                                |
  Then my state should be equal to the following Clojure edn literal: # custom_docstring_types_test.clj:36

Scenario: Converting N-Column DataTables to sequences of Clojure maps # resources/features/custom-docstring-types/from-edn.feature:52
  Given I have a table of data with key names in the first row:       # custom_docstring_types_test.clj:31
    | id | first-name | middle-name | last-name | favorite-color |
    | 1  | Charles    | John        | Taylor    | red            |
    | 2  | Brian      | [empty]     | Jones     | blue           |
    | 3  | William    | David       | Miller    | green          |
    | 4  | Robert     | [empty]     | Smith     | black          |
  Then my state should be equal to the following Clojure edn literal: # custom_docstring_types_test.clj:36

3 Scenarios (3 passed)
8 Steps (8 passed)
0m0.009s



Scenario: Populate state with values from custom DocString inputs and compare them for equality                             # resources/features/custom-docstring-types/from-json.feature:3
  Given that my state starts out as an empty map                                                                            # custom_docstring_types_test.clj:46
  And I want to store the following in my state's :json-sample key                                                          # custom_docstring_types_test.clj:49
  And I want to store the following in my state's :edn-sample key                                                           # custom_docstring_types_test.clj:49
  When I compare the my state's :json-sample and :edn-sample keys to each other for equality, storing the result in :result # custom_docstring_types_test.clj:54
  Then my state's :result equality value should be true                                                                     # custom_docstring_types_test.clj:58

1 Scenarios (1 passed)
5 Steps (5 passed)
0m0.004s



Testing scenario-outline-test

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:12
  Given today is "Sunday"                   # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:13
  Given today is "Monday"                   # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:14
  Given today is "Tuesday"                  # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:15
  Given today is "Wednesday"                # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:16
  Given today is "Thursday"                 # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:17
  Given today is "Friday"                   # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "TGIF!"             # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday # resources/features/scenario-outline.feature:18
  Given today is "Saturday"                 # scenario_outline_test.clj:12
  When I ask whether it's Friday yet        # scenario_outline_test.clj:16
  Then I should be told "Nope"              # scenario_outline_test.clj:21

Scenario Outline: Today is or is not Friday            # resources/features/scenario-outline.feature:19
  Given today is "anything else!"                      # scenario_outline_test.clj:12
  When I ask whether it's Friday yet                   # scenario_outline_test.clj:16
  Then I should be told "That's not a day I recognize" # scenario_outline_test.clj:21

8 Scenarios (8 passed)
24 Steps (24 passed)
0m0.007s



Testing datatables-and-docstrings-test

Scenario: Populate State with DataTable inputs and compare against DocString input             # resources/features/datatables-and-docstrings.feature:3
  Given my state starts out as an empty map                                                    # datatables_and_docstrings_test.clj:11
  And I want to collect pairs of high and low temperatures under the :highs-and-lows state key # datatables_and_docstrings_test.clj:14
  When I have a table of the following high and low temperatures:                              # datatables_and_docstrings_test.clj:18
    | 81 | 49 |
    | 88 | 54 |
    | 76 | 56 |
    | 70 | 48 |
    | 81 | 55 |
  Then my state should be equal to the following Clojure literal:                              # datatables_and_docstrings_test.clj:34

Scenario: Converting Two-Column DataTables to Clojure maps        # resources/features/datatables-and-docstrings.feature:18
  Given I have a key-value table:                                 # datatables_and_docstrings_test.clj:23
    | numeric-value       | 1                                                      |
    | bigint-value        | 7823N                                                  |
    | double-value        | 1.327                                                  |
    | big-decimal-value   | 5.32M                                                  |
    | true-value          | true                                                   |
    | false-value         | false                                                  |
    | set-value           | #{"foo" "bar" "baz"}                                   |
    | vector-value        | [:foo "bar" {:baz true}]                               |
    | ratio-value         | 22/7                                                   |
    | uuid-value          | #uuid"e5fa994f-a073-4f9b-a05e-c8c6f2eea11c"            |
    | string-value        | Multi-word strings don't need to be enclosed in quotes |
    | quoted-string-value | "But they can be, if you prefer"                       |
    | keyword-value       | :some-keyword                                          |
    | nil-value           | [empty]                                                |
  Then my state should be equal to the following Clojure literal: # datatables_and_docstrings_test.clj:34

Scenario: Converting N-Column DataTables to sequences of Clojure maps # resources/features/datatables-and-docstrings.feature:52
  Given I have a table of data with key names in the first row:       # datatables_and_docstrings_test.clj:29
    | id | first-name | middle-name | last-name | favorite-color |
    | 1  | Charles    | John        | Taylor    | red            |
    | 2  | Brian      | [empty]     | Jones     | blue           |
    | 3  | William    | David       | Miller    | green          |
    | 4  | Robert     | [empty]     | Smith     | black          |
  Then my state should be equal to the following Clojure literal:     # datatables_and_docstrings_test.clj:34

3 Scenarios (3 passed)
8 Steps (8 passed)
0m0.006s



Process finished with exit code 0
```